### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: adopt
+          distribution: 'temurin'
           cache: gradle
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
This PR updates GitHub Actions versions:
- actions/checkout from v2 to v4
- actions/setup-java from v2 to v4